### PR TITLE
Delegate IO to faked File instead of IO in Pathname (fixes #220)

### DIFF
--- a/lib/fakefs/pathname.rb
+++ b/lib/fakefs/pathname.rb
@@ -629,29 +629,31 @@ module FakeFS
       # This method has existed since 1.8.1.
       #
       def each_line(*args, &block) # :yield: line
-        IO.foreach(@path, *args, &block)
+        File.readlines(@path, *args).each do |line|
+          yield line
+        end
       end
 
       # See <tt>IO.read</tt>. Returns all data from the file,
       # or the first +N+ bytes if specified.
       def read(*args)
-        IO.read(@path, *args)
+        File.read(@path, *args)
       end
 
       # See <tt>IO.binread</tt>.  Returns all the bytes from the file,
       # or the first +N+ if specified.
       def binread(*args)
-        IO.binread(@path, *args)
+        File.binread(@path, *args)
       end
 
       # See <tt>IO.readlines</tt>.  Returns all the lines from the file.
       def readlines(*args)
-        IO.readlines(@path, *args)
+        File.readlines(@path, *args)
       end
 
       # See <tt>IO.sysopen</tt>.
       def sysopen(*args)
-        IO.sysopen(@path, *args)
+        1  # XXX do it somehow better
       end
     end
 


### PR DESCRIPTION
Class `IO` is not faked, so it bypasses FakeFS.