### PR TITLE
Add FileTest::size method

### DIFF
--- a/lib/fakefs/file_test.rb
+++ b/lib/fakefs/file_test.rb
@@ -15,6 +15,10 @@ module FakeFS
       File.file?(file_name)
     end
 
+    def size?(file_name)
+      File.size?(file_name)
+    end
+
     def writable?(file_name)
       File.writable?(file_name)
     end

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -872,6 +872,27 @@ class FakeFSTest < Test::Unit::TestCase
     assert File.file?(path)
   end
 
+  def test_size_returns_size
+    first_file = 'first.txt'
+    File.open(first_file, 'w') do |f|
+      f.write '12345678'
+    end
+
+    assert_equal File.size?(first_file), 8
+
+    File.open(first_file, 'w') do |f|
+      f.write 'abcd'
+    end
+
+    assert_equal File.size?(first_file), 4
+
+    second_file = 'second.txt'
+    File.open(second_file, 'w') do |f|
+      f.write '1'
+    end
+    assert_equal File.size?(second_file), 1
+  end
+
   def test_File_io_returns_self
     f = File.open('foo', 'w')
     assert_equal f, f.to_io


### PR DESCRIPTION
I don't see any reason to leave out this method, the code I'm trying to test is using it and I'm having troubles covering this code with tests.

To be very specific, I'm trying to test Homebrew Cask code which then calls Homebrew itself and ends up here:
https://github.com/Homebrew/homebrew/blob/bc0c203934f67624a4a3cd2bd15f1b4eb93b0236/Library/Homebrew/download_strategy.rb#L242-244

on following error:
```
NoMethodError:
       undefined method `size?' for FakeFS::FileTest:Module
```

Tests will fail with the code currently on `HEAD`, but pass after merging #268 