### PR TITLE
Delegate IO to faked File instead of IO in Pathname

### DIFF
--- a/lib/fakefs/pathname.rb
+++ b/lib/fakefs/pathname.rb
@@ -629,29 +629,31 @@ module FakeFS
       # This method has existed since 1.8.1.
       #
       def each_line(*args, &block) # :yield: line
-        IO.foreach(@path, *args, &block)
+        File.readlines(@path, *args).each do |line|
+          yield line
+        end
       end
 
       # See <tt>IO.read</tt>. Returns all data from the file,
       # or the first +N+ bytes if specified.
       def read(*args)
-        IO.read(@path, *args)
+        File.read(@path, *args)
       end
 
       # See <tt>IO.binread</tt>.  Returns all the bytes from the file,
       # or the first +N+ if specified.
       def binread(*args)
-        IO.binread(@path, *args)
+        File.binread(@path, *args)
       end
 
       # See <tt>IO.readlines</tt>.  Returns all the lines from the file.
       def readlines(*args)
-        IO.readlines(@path, *args)
+        File.readlines(@path, *args)
       end
 
       # See <tt>IO.sysopen</tt>.
       def sysopen(*args)
-        IO.sysopen(@path, *args)
+        1  # XXX do it somehow better
       end
     end
 

--- a/lib/fakefs/pathname.rb
+++ b/lib/fakefs/pathname.rb
@@ -629,8 +629,8 @@ module FakeFS
       # This method has existed since 1.8.1.
       #
       def each_line(*args, &block) # :yield: line
-        File.readlines(@path, *args).each do |line|
-          yield line
+        File.open(@path, 'r') do |io|
+          io.each_line(*args, &block)
         end
       end
 
@@ -651,13 +651,13 @@ module FakeFS
         File.readlines(@path, *args)
       end
 
-      # See <tt>IO.sysopen</tt>.
+      # See <tt>IO.sysopen</tt>. Not supported by fakefs.
       def sysopen(*args)
-        1  # XXX do it somehow better
+        raise NotImplementedError, 'sysopen is not supported by fakefs'
       end
     end
 
-    # Pathnam class
+    # Pathname class
     class Pathname    # * File *
       # See <tt>File.atime</tt>.  Returns last access time.
       def atime

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -2424,18 +2424,6 @@ class FakeFSTest < Test::Unit::TestCase
     assert FileTest.writable?('dir'), 'directories are writable'
   end
 
-  def test_pathname_exists_returns_correct_value
-    FileUtils.touch 'foo'
-    assert Pathname.new('foo').exist?
-
-    assert !Pathname.new('bar').exist?
-  end
-
-  def test_pathname_method_is_faked
-    FileUtils.mkdir_p '/path'
-    assert Pathname('/path').exist?, 'Pathname() method is faked'
-  end
-
   def test_dir_mktmpdir
     FileUtils.mkdir '/tmp'
 

--- a/test/pathname_test.rb
+++ b/test/pathname_test.rb
@@ -1,0 +1,73 @@
+require 'test_helper'
+
+# Fake Pathname test class
+class FakePathnameTest < Test::Unit::TestCase
+  include FakeFS
+
+  def setup
+    FakeFS.activate!
+    FileSystem.clear
+
+    @path = 'foo'
+    @pathname = Pathname.new(@path)
+  end
+
+  def teardown
+    FakeFS.deactivate!
+  end
+
+  def test_filetest_exists_returns_correct_value
+    assert !@pathname.exist?
+
+    File.write(@path, '')
+
+    assert @pathname.exist?
+  end
+
+  def test_io_each_line_with_block_yields_lines
+    File.write(@path, "one\ntwo\nthree\n")
+
+    yielded = []
+    @pathname.each_line { |line| yielded << line }
+
+    assert_equal yielded, ["one\n", "two\n", "three\n"]
+  end
+
+  def test_io_each_line_without_block_returns_enumerator
+    File.write(@path, '')
+
+    assert @pathname.each_line.is_a?(Enumerator)
+  end
+
+  def test_io_read_returns_file_contents
+    File.write(@path, "some\ncontent")
+
+    assert_equal @pathname.read, "some\ncontent"
+    assert_equal @pathname.read(6), "some\nc"
+    assert_equal @pathname.read(4, 3), "e\nco"
+  end
+
+  def test_io_binread_returns_file_contents
+    File.write(@path, "some\ncontent")
+
+    assert_equal @pathname.binread, "some\ncontent"
+    assert_equal @pathname.binread(6), "some\nc"
+    assert_equal @pathname.binread(4, 3), "e\nco"
+  end
+
+  def test_io_binread_reads_contents_as_binary
+    File.write(@path, "some\ncontent")
+
+    assert_equal @pathname.binread.encoding.name, 'ASCII-8BIT'
+  end
+
+  def test_io_readlines_returns_array_of_lines
+    File.write(@path, "one\ntwo\nthree\n")
+
+    assert_equal @pathname.readlines, ["one\n", "two\n", "three\n"]
+  end
+
+  def test_io_sysopen_is_unsupported
+    assert_raise(NotImplementedError) { @pathname.sysopen }
+  end
+end


### PR DESCRIPTION
Addresses #220 by incorporating @jirutka's fix with minor changes and unit tests.