### PR TITLE
Support for Ruby 2.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+language: ruby
+sudo: false
 rvm:
   - 1.9.3
   - 2.0.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,4 @@ matrix:
     - rvm: jruby
     - rvm: rbx-19mode
 before_install:
-  - gem update --system 2.1.11
   - gem --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.1
+  - 2.2.0
   - jruby
   - rbx-19mode
 matrix:

--- a/fakefs.gemspec
+++ b/fakefs.gemspec
@@ -22,4 +22,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.3"
   spec.add_development_dependency "rspec", "~> 3.1"
   spec.add_development_dependency 'rubocop', '~>0.25'
+  spec.add_development_dependency 'minitest', '~> 5.5'
+  spec.add_development_dependency 'minitest-rg', '~> 5.1'
 end

--- a/lib/fakefs/fake/file.rb
+++ b/lib/fakefs/fake/file.rb
@@ -2,7 +2,7 @@ module FakeFS
   # Fake file class
   class FakeFile
     attr_accessor :name, :parent, :content, :mtime, :atime, :mode, :uid, :gid
-    attr_reader :ctime
+    attr_reader :ctime, :birthtime
 
     # Inode class
     class Inode
@@ -34,15 +34,16 @@ module FakeFS
     end
 
     def initialize(name = nil, parent = nil)
-      @name   = name
-      @parent = parent
-      @inode  = Inode.new(self)
-      @ctime  = Time.now
-      @mtime  = @ctime
-      @atime  = @ctime
-      @mode   = 0100000 + (0666 - File.umask)
-      @uid    = Process.uid
-      @gid    = Process.gid
+      @name      = name
+      @parent    = parent
+      @inode     = Inode.new(self)
+      @ctime     = Time.now
+      @mtime     = @ctime
+      @atime     = @ctime
+      @birthtime = @ctime
+      @mode      = 0100000 + (0666 - File.umask)
+      @uid       = Process.uid
+      @gid       = Process.gid
     end
 
     attr_accessor :inode

--- a/test/dir/tempfile_test.rb
+++ b/test/dir/tempfile_test.rb
@@ -2,16 +2,15 @@ require 'test_helper'
 require 'tempfile'
 
 # Tempfile test class
-class TempfileTest < Test::Unit::TestCase
+class TempfileTest < Minitest::Test
   include FakeFS
 
   if RUBY_VERSION >= '2.1'
     def test_should_not_raise_error
       FakeFS do
-        assert_nothing_raised do
-          FileUtils.mkdir_p('/tmp')
-          Tempfile.open('test')
-        end
+        # nothing raised
+        FileUtils.mkdir_p('/tmp')
+        Tempfile.open('test')
       end
     end
   else

--- a/test/fake/file/join_test.rb
+++ b/test/fake/file/join_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 # File join test class
-class FileJoin < Test::Unit::TestCase
+class FileJoin < Minitest::Test
   def setup
     FakeFS.activate!
   end

--- a/test/fake/file/lstat_test.rb
+++ b/test/fake/file/lstat_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 # File stat test class
-class FileStat < Test::Unit::TestCase
+class FileStat < Minitest::Test
   def setup
     FakeFS.activate!
     FakeFS::FileSystem.clear
@@ -35,7 +35,7 @@ class FileStat < Test::Unit::TestCase
     File.open('foo', 'w') { |f| f << 'some content' }
     File.symlink 'foo', 'my_symlink'
 
-    assert_not_equal File.lstat('my_symlink').size, File.lstat('foo').size
+    refute_equal File.lstat('my_symlink').size, File.lstat('foo').size
   end
 
   def test_should_report_on_symlink_itself_with_size_instance_method
@@ -45,7 +45,7 @@ class FileStat < Test::Unit::TestCase
     file = File.open('foo')
     symlink = File.open('my_symlink')
 
-    assert_not_equal file.lstat.size, symlink.lstat.size
+    refute_equal file.lstat.size, symlink.lstat.size
   end
 
   def test_symlink_size_is_size_of_path_pointed_to

--- a/test/fake/file/stat_test.rb
+++ b/test/fake/file/stat_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 # File stat test class
-class FileStat < Test::Unit::TestCase
+class FileStat < Minitest::Test
   def setup
     FakeFS.activate!
     FakeFS::FileSystem.clear

--- a/test/fake/file/sysseek_test.rb
+++ b/test/fake/file/sysseek_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 # File SysSeek test class
-class FileSysSeek < Test::Unit::TestCase
+class FileSysSeek < Minitest::Test
   def setup
     FakeFS.activate!
     FakeFS::FileSystem.clear

--- a/test/fake/file/syswrite_test.rb
+++ b/test/fake/file/syswrite_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 # File SysWrite test class
-class FileSysWriteTest < Test::Unit::TestCase
+class FileSysWriteTest < Minitest::Test
   def setup
     FakeFS.activate!
     FakeFS::FileSystem.clear

--- a/test/fake/file_test.rb
+++ b/test/fake/file_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 # Fake File test class
-class FakeFileTest < Test::Unit::TestCase
+class FakeFileTest < Minitest::Test
   include FakeFS
 
   def setup
@@ -72,7 +72,7 @@ class FakeFileTest < Test::Unit::TestCase
 
   def test_clone_creates_new_inode
     clone = @file.clone
-    assert !clone.inode.equal?(@file.inode)
+    refute clone.inode.equal?(@file.inode)
   end
 
   def test_cloning_does_not_use_same_content_object

--- a/test/fake/symlink_test.rb
+++ b/test/fake/symlink_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 # Fake symlink test class
-class FakeSymlinkTest < Test::Unit::TestCase
+class FakeSymlinkTest < Minitest::Test
   include FakeFS
 
   def test_symlink_has_method_missing_as_private
@@ -15,7 +15,7 @@ class FakeSymlinkTest < Test::Unit::TestCase
            'has public method \#to_s'
     assert fake_symlink.respond_to?(:to_s, true),
            'has public or private method \#to_s'
-    assert !fake_symlink.respond_to?(:initialize, false),
+    refute fake_symlink.respond_to?(:initialize, false),
            'has private method \#initialize'
     assert fake_symlink.respond_to?(:initialize, true),
            'has private method \#initialize'
@@ -25,8 +25,8 @@ class FakeSymlinkTest < Test::Unit::TestCase
     fake_symlink = FakeSymlink.new('foo')
     assert_equal fake_symlink.respond_to?(:to_s),
                  fake_symlink.entry.respond_to?(:to_s)
-    assert_not_equal fake_symlink.respond_to?(:to_s),
-                     fake_symlink.entry.respond_to?(:initialize)
+    refute_equal fake_symlink.respond_to?(:to_s),
+                 fake_symlink.entry.respond_to?(:initialize)
     assert_equal fake_symlink.respond_to?(:initialize),
                  fake_symlink.entry.respond_to?(:initialize)
   end

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -2,8 +2,10 @@
 require 'test_helper'
 
 # FakeFS tests
-class FakeFSTest < Test::Unit::TestCase
+class FakeFSTest < Minitest::Test
   include FakeFS
+
+  i_suck_and_my_tests_are_order_dependent!
 
   def setup
     FakeFS.activate!
@@ -73,14 +75,14 @@ class FakeFSTest < Test::Unit::TestCase
   def test_raises_error_when_creating_a_new_dir_over_existing_file
     File.open('file', 'w') { |f| f << 'This is a file, not a directory.' }
 
-    assert_raise Errno::EEXIST do
+    assert_raises Errno::EEXIST do
       FileUtils.mkdir_p('file/subdir')
     end
 
     FileUtils.mkdir('dir')
     File.open('dir/subfile', 'w') { |f| f << 'This is a file inside a directory.' }
 
-    assert_raise Errno::EEXIST do
+    assert_raises Errno::EEXIST do
       FileUtils.mkdir_p('dir/subfile/subdir')
     end
   end
@@ -106,21 +108,17 @@ class FakeFSTest < Test::Unit::TestCase
   end
 
   def test_unlink_errors_on_file_not_found
-    assert_raise Errno::ENOENT do
+    assert_raises Errno::ENOENT do
       FileUtils.rm('/foo')
     end
   end
 
   def test_unlink_doesnt_error_on_file_not_found_when_forced
-    assert_nothing_raised do
-      FileUtils.rm('/foo', force: true)
-    end
+    FileUtils.rm('/foo', force: true)
   end
 
   def test_unlink_doesnt_error_on_file_not_found_with_rm_rf
-    assert_nothing_raised do
-      FileUtils.rm_rf('/foo')
-    end
+    FileUtils.rm_rf('/foo')
   end
 
   def test_can_delete_directories
@@ -199,7 +197,7 @@ class FakeFSTest < Test::Unit::TestCase
 
   def test_symlink_with_missing_refferent_does_not_exist
     File.symlink('/foo', '/bar')
-    assert !File.exist?('/bar')
+    refute File.exist?('/bar')
   end
 
   def test_can_create_symlinks
@@ -251,7 +249,7 @@ class FakeFSTest < Test::Unit::TestCase
     FileUtils.touch('/file')
     FileUtils.mkdir_p('/a/b')
     FileUtils.ln_s('../../file_foo', '/a/b/symlink')
-    assert !File.exist?('/a/b/symlink')
+    refute File.exist?('/a/b/symlink')
   end
 
   def test_symlink_with_relative_path_has_correct_target
@@ -274,9 +272,9 @@ class FakeFSTest < Test::Unit::TestCase
   def test_symlink_to_symlinks_should_raise_error_if_dir_doesnt_exist
     FileUtils.mkdir_p(target = '/path/to/foo/target')
 
-    assert !Dir.exist?('/path/to/bar')
+    refute Dir.exist?('/path/to/bar')
 
-    assert_raise Errno::ENOENT do
+    assert_raises Errno::ENOENT do
       FileUtils.ln_s(target, '/path/to/bar/symlink')
     end
   end
@@ -299,7 +297,7 @@ class FakeFSTest < Test::Unit::TestCase
   end
 
   def test_nothing_is_sticky
-    assert !File.sticky?('/')
+    refute File.sticky?('/')
   end
 
   def test_can_create_files_in_existing_dir
@@ -496,7 +494,8 @@ class FakeFSTest < Test::Unit::TestCase
       f.write 'Yatta!'
     end
 
-    assert_nothing_raised { File.read(path, mode: 'r:UTF-8:-') }
+    # nothing raised
+    File.read(path, mode: 'r:UTF-8:-')
   end
 
   def test_file_read_respects_args
@@ -519,7 +518,7 @@ class FakeFSTest < Test::Unit::TestCase
   end
 
   def test_raises_error_when_opening_with_binary_mode_only
-    assert_raise ArgumentError do
+    assert_raises ArgumentError do
       File.open('/foo', 'b')
     end
   end
@@ -598,7 +597,7 @@ class FakeFSTest < Test::Unit::TestCase
   end
 
   def test_raises_error_on_mtime_if_file_does_not_exist
-    assert_raise Errno::ENOENT do
+    assert_raises Errno::ENOENT do
       File.mtime('/path/to/file.txt')
     end
   end
@@ -630,7 +629,7 @@ class FakeFSTest < Test::Unit::TestCase
   end
 
   def test_raises_error_on_ctime_if_file_does_not_exist
-    assert_raise Errno::ENOENT do
+    assert_raises Errno::ENOENT do
       File.ctime('file.txt')
     end
   end
@@ -641,7 +640,7 @@ class FakeFSTest < Test::Unit::TestCase
   end
 
   def test_raises_error_on_atime_if_file_does_not_exist
-    assert_raise Errno::ENOENT do
+    assert_raises Errno::ENOENT do
       File.atime('file.txt')
     end
   end
@@ -713,7 +712,7 @@ class FakeFSTest < Test::Unit::TestCase
   end
 
   def test_utime_raises_error_if_path_does_not_exist
-    assert_raise Errno::ENOENT do
+    assert_raises Errno::ENOENT do
       File.utime(Time.now, Time.now, '/path/to/file.txt')
     end
   end
@@ -787,7 +786,7 @@ class FakeFSTest < Test::Unit::TestCase
     file = File.open(path, 'w')
     file.write 'Yada'
     file.close
-    assert_raise IOError do
+    assert_raises IOError do
       file.read
     end
   end
@@ -797,7 +796,7 @@ class FakeFSTest < Test::Unit::TestCase
     file = File.open(path, 'w')
     file.write 'Yada'
     file.close
-    assert_raise IOError do
+    assert_raises IOError do
       file << 'foo'
     end
   end
@@ -821,17 +820,14 @@ class FakeFSTest < Test::Unit::TestCase
   end
 
   def test_file_object_initialization_with_mode_in_hash_parameter
-    assert_nothing_raised do
-      File.open('file.txt', mode: 'w') { |f| f.write 'Yatta!' }
-    end
+    File.open('file.txt', mode: 'w') { |f| f.write 'Yatta!' }
   end
 
   def test_file_object_initialization_with_brackets_in_filename
     filename = 'bracket[1](2).txt'
     expected_contents = 'Yokudekimashita'
-    assert_nothing_raised do
-      File.open(filename, mode: 'w') { |f| f.write "#{expected_contents}" }
-    end
+    # nothing raised
+    File.open(filename, mode: 'w') { |f| f.write "#{expected_contents}" }
     the_file = Dir['/*']
     assert_equal the_file.length, 1
     assert_equal the_file[0], "/#{filename}"
@@ -842,15 +838,14 @@ class FakeFSTest < Test::Unit::TestCase
   def test_file_object_initialization_with_brackets_in_filename
     filename = "\u65e5\u672c\u8a9e.txt"
     expected_contents = 'Yokudekimashita'
-    assert_nothing_raised do
-      File.open(filename,  mode: 'w') { |f| f.write "#{expected_contents}" }
-    end
+    # nothing raised
+    File.open(filename,  mode: 'w') { |f| f.write "#{expected_contents}" }
     contents = File.open("/#{filename}").read
     assert_equal contents, expected_contents
   end
 
   def test_file_read_errors_appropriately
-    assert_raise Errno::ENOENT do
+    assert_raises Errno::ENOENT do
       File.read('anything')
     end
   end
@@ -858,7 +853,7 @@ class FakeFSTest < Test::Unit::TestCase
   def test_file_read_errors_on_directory
     FileUtils.mkdir_p('a_directory')
 
-    assert_raise Errno::EISDIR do
+    assert_raises Errno::EISDIR do
       File.read('a_directory')
     end
   end
@@ -918,7 +913,7 @@ class FakeFSTest < Test::Unit::TestCase
   end
 
   def test_executable_returns_false_for_non_existent_files
-    assert !File.executable?('/does/not/exist')
+    refute File.executable?('/does/not/exist')
   end
 
   def test_can_chown_files
@@ -1078,7 +1073,7 @@ class FakeFSTest < Test::Unit::TestCase
   def test_file_utils_cp_allows_noop_option
     File.open('foo', 'w') { |f| f << 'TEST' }
     FileUtils.cp 'foo', 'bar', noop: true
-    assert !File.exist?('bar'), 'does not actually copy'
+    refute File.exist?('bar'), 'does not actually copy'
   end
 
   def test_file_utils_cp_raises_on_invalid_option
@@ -1095,7 +1090,7 @@ class FakeFSTest < Test::Unit::TestCase
   def test_file_utils_cp_r_allows_noop_option
     FileUtils.touch '/foo'
     FileUtils.cp_r '/foo', '/bar', noop: true
-    assert !File.exist?('/bar'), 'does not actually copy'
+    refute File.exist?('/bar'), 'does not actually copy'
   end
 
   def test_dir_glob_handles_root
@@ -1219,7 +1214,7 @@ class FakeFSTest < Test::Unit::TestCase
   def test_file_should_not_respond_to_string_io_unique_methods
     uniq_string_io_methods = StringIO.instance_methods - RealFile.instance_methods
     uniq_string_io_methods.each do |method_name|
-      assert !File.instance_methods.include?(method_name), "File responds to #{method_name}"
+      refute File.instance_methods.include?(method_name), "File responds to #{method_name}"
     end
   end
 
@@ -1230,7 +1225,7 @@ class FakeFSTest < Test::Unit::TestCase
 
   def test_is_not_a_stringio
     File.open('foo', 'w') do |f|
-      assert !f.is_a?(StringIO), 'File is not a StringIO'
+      refute f.is_a?(StringIO), 'File is not a StringIO'
     end
   end
 
@@ -1301,7 +1296,7 @@ class FakeFSTest < Test::Unit::TestCase
   end
 
   def test_chdir_should_flop_over_and_die_if_the_dir_doesnt_exist
-    assert_raise(Errno::ENOENT) do
+    assert_raises(Errno::ENOENT) do
       Dir.chdir('/nope') do
         1
       end
@@ -1411,10 +1406,10 @@ class FakeFSTest < Test::Unit::TestCase
   end
 
   def test_mv_should_raise_error_on_missing_file
-    assert_raise(Errno::ENOENT) do
+    assert_raises(Errno::ENOENT) do
       FileUtils.mv 'blafgag', 'foo'
     end
-    exception = assert_raise(Errno::ENOENT) do
+    exception = assert_raises(Errno::ENOENT) do
       FileUtils.mv %w(foo bar), 'destdir'
     end
     assert_equal 'No such file or directory - foo', exception.message
@@ -1465,7 +1460,7 @@ class FakeFSTest < Test::Unit::TestCase
     FileUtils.touch 'foo'
     FileUtils.mv 'foo', 'bar', noop: true
     assert File.exist?('foo'), 'does not remove src'
-    assert !File.exist?('bar'), 'does not create target'
+    refute File.exist?('bar'), 'does not create target'
   end
 
   def test_mv_raises_when_moving_file_onto_directory
@@ -1489,11 +1484,11 @@ class FakeFSTest < Test::Unit::TestCase
     FileUtils.mv %w(stuff other), 'dir', force: true
     assert File.exist?('stuff'), 'failed move remains where it was'
     assert File.exist?('dir/other'), 'successful one is moved'
-    assert !File.exist?('other'), 'successful one is moved'
+    refute File.exist?('other'), 'successful one is moved'
 
     FileUtils.mv 'stuff', '/this/path/is/not/here', force: true
     assert File.exist?('stuff'), 'failed move remains where it was'
-    assert !File.exist?('/this/path/is/not/here'), 'nothing is created for a failed move'
+    refute File.exist?('/this/path/is/not/here'), 'nothing is created for a failed move'
   end
 
   def test_cp_actually_works
@@ -1523,7 +1518,7 @@ class FakeFSTest < Test::Unit::TestCase
   def test_cp_fails_on_array_of_files_into_non_directory
     File.open('foo', 'w') { |f| f.write 'footext' }
 
-    exception = assert_raise(Errno::ENOTDIR) do
+    exception = assert_raises(Errno::ENOTDIR) do
       FileUtils.cp(%w(foo), 'baz')
     end
     assert_equal 'Not a directory - baz', exception.to_s
@@ -1538,7 +1533,7 @@ class FakeFSTest < Test::Unit::TestCase
   end
 
   def test_cp_fails_on_no_source
-    assert_raise Errno::ENOENT do
+    assert_raises Errno::ENOENT do
       FileUtils.cp('foo', 'baz')
     end
   end
@@ -1546,7 +1541,7 @@ class FakeFSTest < Test::Unit::TestCase
   def test_cp_fails_on_directory_copy
     FileUtils.mkdir_p 'baz'
 
-    assert_raise Errno::EISDIR do
+    assert_raises Errno::EISDIR do
       FileUtils.cp('baz', 'bar')
     end
   end
@@ -1567,7 +1562,7 @@ class FakeFSTest < Test::Unit::TestCase
   def test_cp_r_should_raise_error_on_missing_file
     # Yes, this error sucks, but it conforms to the original Ruby
     # method.
-    assert_raise(RuntimeError) do
+    assert_raises(RuntimeError) do
       FileUtils.cp_r 'blafgag', 'foo'
     end
   end
@@ -1643,7 +1638,7 @@ class FakeFSTest < Test::Unit::TestCase
 
   def test_clone_clones_normal_files
     RealFile.open(here('foo'), 'w') { |f| f.write 'bar' }
-    assert !File.exist?(here('foo'))
+    refute File.exist?(here('foo'))
     FileSystem.clone(here('foo'))
     assert_equal 'bar', File.open(here('foo')) { |f| f.read }
   ensure
@@ -1664,7 +1659,7 @@ class FakeFSTest < Test::Unit::TestCase
   def test_clone_clones_dot_files_even_hard_to_find_ones
     act_on_real_fs { RealFileUtils.mkdir_p(here('subdir/.bar/baz/.quux/foo')) }
 
-    assert !File.exist?(here('subdir'))
+    refute File.exist?(here('subdir'))
 
     FileSystem.clone(here('subdir'))
     assert_equal ['.', '..', '.bar'], Dir.entries(here('subdir'))
@@ -1686,10 +1681,10 @@ class FakeFSTest < Test::Unit::TestCase
   def test_clone_with_target_specified
     act_on_real_fs { RealFileUtils.mkdir_p(here('subdir/.bar/baz/.quux/foo')) }
 
-    assert !File.exist?(here('subdir'))
+    refute File.exist?(here('subdir'))
 
     FileSystem.clone(here('subdir'), here('subdir2'))
-    assert !File.exist?(here('subdir'))
+    refute File.exist?(here('subdir'))
     assert_equal ['.', '..', '.bar'], Dir.entries(here('subdir2'))
     assert_equal ['.', '..', 'foo'], Dir.entries(here('subdir2/.bar/baz/.quux'))
   ensure
@@ -1707,7 +1702,7 @@ class FakeFSTest < Test::Unit::TestCase
       assert RealFile.symlink?(symlink), 'real symlink is in place'
     end
 
-    assert !File.exist?(original), 'file does not already exist'
+    refute File.exist?(original), 'file does not already exist'
 
     FileSystem.clone(File.dirname(original))
     assert File.symlink?(symlink), 'symlinks are cloned as symlinks'
@@ -1729,7 +1724,7 @@ class FakeFSTest < Test::Unit::TestCase
       assert RealFile.symlink?(symlink), 'real symlink is in place'
     end
 
-    assert !File.exist?(original_file), 'file does not already exist'
+    refute File.exist?(original_file), 'file does not already exist'
 
     FileSystem.clone(File.dirname(original))
     assert File.symlink?(symlink), 'symlinks are cloned as symlinks'
@@ -1794,9 +1789,8 @@ class FakeFSTest < Test::Unit::TestCase
   def test_new_directory
     FileUtils.mkdir_p('/this/path/should/be/here')
 
-    assert_nothing_raised do
-      Dir.new('/this/path/should/be/here')
-    end
+    # nothing raised
+    Dir.new('/this/path/should/be/here')
   end
 
   def test_new_directory_does_not_work_if_dir_path_cannot_be_found
@@ -1909,19 +1903,19 @@ class FakeFSTest < Test::Unit::TestCase
     dir = Dir.new('/this/path/should/be/here')
 
     d = dir.read
-    assert_not_nil d
+    refute_nil d
     d = dir.read
-    assert_not_nil d
+    refute_nil d
     d = dir.read
-    assert_not_nil d
+    refute_nil d
     d = dir.read
-    assert_not_nil d
+    refute_nil d
     d = dir.read
-    assert_not_nil d
+    refute_nil d
     d = dir.read
-    assert_not_nil d
+    refute_nil d
     d = dir.read
-    assert_not_nil d
+    refute_nil d
     d = dir.read
     assert_nil d
   end
@@ -2260,7 +2254,7 @@ class FakeFSTest < Test::Unit::TestCase
 
     File.delete('/foo')
 
-    assert !File.exist?('/foo')
+    refute File.exist?('/foo')
   end
 
   def test_can_delete_multiple_files_with_delete
@@ -2269,8 +2263,8 @@ class FakeFSTest < Test::Unit::TestCase
 
     File.delete('/foo', '/bar')
 
-    assert !File.exist?('/foo')
-    assert !File.exist?('/bar')
+    refute File.exist?('/foo')
+    refute File.exist?('/bar')
   end
 
   def test_delete_returns_zero_when_no_filename_given
@@ -2319,7 +2313,7 @@ class FakeFSTest < Test::Unit::TestCase
     File.unlink('/bar')
 
     assert File.exist?('/foo')
-    assert !File.exist?('/bar')
+    refute File.exist?('/bar')
   end
 
   def test_delete_works_with_symlink_source
@@ -2328,7 +2322,7 @@ class FakeFSTest < Test::Unit::TestCase
 
     File.unlink('/foo')
 
-    assert !File.exist?('/foo')
+    refute File.exist?('/foo')
   end
 
   def test_file_seek_returns_0
@@ -2389,7 +2383,7 @@ class FakeFSTest < Test::Unit::TestCase
     assert FileTest.exist?('/path/to/')
 
     FileUtils.rmdir('/path/to/dir')
-    assert !FileTest.exist?('/path/to/dir')
+    refute FileTest.exist?('/path/to/dir')
   end
 
   def test_filetest_directory_returns_correct_values
@@ -2397,7 +2391,7 @@ class FakeFSTest < Test::Unit::TestCase
     assert FileTest.directory?('/path/to/somedir')
 
     FileUtils.rm_r '/path/to/somedir'
-    assert !FileTest.directory?('/path/to/somedir')
+    refute FileTest.directory?('/path/to/somedir')
   end
 
   def test_filetest_file_returns_correct_values
@@ -2408,14 +2402,14 @@ class FakeFSTest < Test::Unit::TestCase
     assert FileTest.file?(path)
 
     FileUtils.rm path
-    assert !FileTest.file?(path)
+    refute FileTest.file?(path)
 
     FileUtils.mkdir_p '/path/to/somedir'
-    assert !FileTest.file?('/path/to/somedir')
+    refute FileTest.file?('/path/to/somedir')
   end
 
   def test_filetest_readable_returns_correct_values
-    assert !FileTest.readable?('not-here.txt'), 'missing files are not readable'
+    refute FileTest.readable?('not-here.txt'), 'missing files are not readable'
 
     FileUtils.touch 'here.txt'
     assert FileTest.readable?('here.txt'), 'existing files are readable'
@@ -2425,7 +2419,7 @@ class FakeFSTest < Test::Unit::TestCase
   end
 
   def test_filetest_writable_returns_correct_values
-    assert !FileTest.writable?('not-here.txt'), 'missing files are not writable'
+    refute FileTest.writable?('not-here.txt'), 'missing files are not writable'
 
     FileUtils.touch 'here.txt'
     assert FileTest.writable?('here.txt'), 'existing files are writable'
@@ -2445,7 +2439,7 @@ class FakeFSTest < Test::Unit::TestCase
       tmpdir = t
       assert File.directory?(t)
     end
-    assert !File.directory?(tmpdir)
+    refute File.directory?(tmpdir)
   end
 
   def test_activating_returns_true
@@ -2653,9 +2647,8 @@ class FakeFSTest < Test::Unit::TestCase
     def test_fdatasync
       File.open('foo', 'w') do |f|
         f << 'Yada Yada'
-        assert_nothing_raised do
-          f.fdatasync
-        end
+        # nothing raised
+        f.fdatasync
       end
     end
 
@@ -2677,9 +2670,8 @@ class FakeFSTest < Test::Unit::TestCase
   if RUBY_VERSION >= '1.9.3'
     def test_advise
       File.open('foo', 'w') do |f|
-        assert_nothing_raised do
-          f.advise(:normal, 0, 0)
-        end
+        # nothing raised
+        f.advise(:normal, 0, 0)
       end
     end
 

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -1202,7 +1202,8 @@ class FakeFSTest < Minitest::Test
     :echo?, :echo=, :noecho,
     :winsize, :winsize=,
     :getch,
-    :iflush, :ioflush, :oflush
+    :iflush, :ioflush, :oflush,
+    :pathconf
   ]
 
   def test_every_method_in_file_is_in_fake_fs_file
@@ -2735,6 +2736,24 @@ class FakeFSTest < Minitest::Test
     def test_can_read_binary_data_using_binread
       File.open('foo', 'wb') { |f| f << "\u0000\u0000\u0000\u0003\u0000\u0003\u0000\xA3\u0000\u0000\u0000y\u0000\u0000\u0000\u0000\u0000" }
       assert_equal "\x00\x00\x00\x03\x00\x03\x00\xA3\x00\x00\x00y\x00\x00\x00\x00\x00".force_encoding('ASCII-8BIT'), File.binread('foo')
+    end
+  end
+
+  if RUBY_VERSION >= '2.2.0'
+    def test_raises_error_on_birthtime_if_file_does_not_exist
+      assert_raises Errno::ENOENT do
+        File.birthtime('file.txt')
+      end
+    end
+
+    def test_can_return_birthtime_on_existing_file
+      File.open('foo', 'w') { |f| f << 'some content' }
+      assert File.birthtime('foo').is_a?(Time)
+    end
+
+    def test_file_birthtime_is_equal_to_file_stat_birthtime
+      File.open('foo', 'w') { |f| f << 'some content' }
+      assert_equal File.stat('foo').birthtime, File.birthtime('foo')
     end
   end
 end

--- a/test/file/stat_test.rb
+++ b/test/file/stat_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 # File stat test class
-class FileStatTest < Test::Unit::TestCase
+class FileStatTest < Minitest::Test
   include FakeFS
 
   def setup
@@ -46,14 +46,14 @@ class FileStatTest < Test::Unit::TestCase
   def test_symlink_should_be_false_when_not_a_symlink
     FileUtils.touch('/foo')
 
-    assert !File::Stat.new('/foo').symlink?
+    refute File::Stat.new('/foo').symlink?
     assert File::Stat.new('/foo').ftype == 'file'
   end
 
   def test_should_return_false_for_directory_when_not_a_directory
     FileUtils.touch('/foo')
 
-    assert !File::Stat.new('/foo').directory?
+    refute File::Stat.new('/foo').directory?
     assert File::Stat.new('/foo').ftype == 'file'
   end
 
@@ -95,7 +95,7 @@ class FileStatTest < Test::Unit::TestCase
 
   def test_file_zero?
     File.open('testfile', 'w') { |f| f << 'test' }
-    assert !File.stat('testfile').zero?, 'testfile has size 4, not zero'
+    refute File.stat('testfile').zero?, 'testfile has size 4, not zero'
 
     FileUtils.touch('testfile2')
     assert File.stat('testfile2').zero?, 'testfile2 has size 0, but stat lied'
@@ -124,7 +124,7 @@ class FileStatTest < Test::Unit::TestCase
 
   def test_responds_to_sticky
     FileUtils.touch('/foo')
-    assert !File::Stat.new('/foo').sticky?
+    refute File::Stat.new('/foo').sticky?
   end
 
   def test_responds_to_world_readable
@@ -144,7 +144,7 @@ class FileStatTest < Test::Unit::TestCase
     if RUBY_VERSION > '1.9'
       assert File.respond_to?(:realpath)
     else
-      assert !File.respond_to?(:realpath)
+      refute File.respond_to?(:realpath)
     end
   end
 
@@ -152,7 +152,7 @@ class FileStatTest < Test::Unit::TestCase
     if RUBY_VERSION >= '1.9.2'
       assert File.respond_to?(:realdirpath)
     else
-      assert !File.respond_to?(:realdirpath)
+      refute File.respond_to?(:realdirpath)
     end
   end
 end

--- a/test/kernel_test.rb
+++ b/test/kernel_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 # Kernel test class
-class KernelTest < Test::Unit::TestCase
+class KernelTest < Minitest::Test
   include FakeFS
   def setup
     FakeFS.deactivate!

--- a/test/pathname_test.rb
+++ b/test/pathname_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 # Fake Pathname test class
-class FakePathnameTest < Test::Unit::TestCase
+class FakePathnameTest < Minitest::Test
   include FakeFS
 
   def setup
@@ -17,7 +17,7 @@ class FakePathnameTest < Test::Unit::TestCase
   end
 
   def test_filetest_exists_returns_correct_value
-    assert !@pathname.exist?
+    refute @pathname.exist?
 
     File.write(@path, '')
 
@@ -68,6 +68,6 @@ class FakePathnameTest < Test::Unit::TestCase
   end
 
   def test_io_sysopen_is_unsupported
-    assert_raise(NotImplementedError) { @pathname.sysopen }
+    assert_raises(NotImplementedError) { @pathname.sysopen }
   end
 end

--- a/test/safe_test.rb
+++ b/test/safe_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 # FakeFS safe test class
-class FakeFSSafeTest < Test::Unit::TestCase
+class FakeFSSafeTest < Minitest::Test
   def setup
     FakeFS.deactivate!
   end
@@ -13,7 +13,7 @@ class FakeFSSafeTest < Test::Unit::TestCase
   def test_FakeFS_activated_is_accurate
     2.times do
       FakeFS.deactivate!
-      assert !FakeFS.activated?
+      refute FakeFS.activated?
       FakeFS.activate!
       assert FakeFS.activated?
     end
@@ -27,7 +27,7 @@ class FakeFSSafeTest < Test::Unit::TestCase
       assert File.exist?(path)
     end
 
-    assert !File.exist?(path)
+    refute File.exist?(path)
   end
 
   def test_FakeFS_method_returns_value_of_yield
@@ -55,19 +55,19 @@ class FakeFSSafeTest < Test::Unit::TestCase
       assert FakeFS.activated?
     end
 
-    assert !FakeFS.activated?
+    refute FakeFS.activated?
   end
 
   def test_FakeFS_method_can_be_nested_with_FakeFS_without
     FakeFS do
       assert FakeFS.activated?
       FakeFS.without do
-        assert !FakeFS.activated?
+        refute FakeFS.activated?
       end
       assert FakeFS.activated?
     end
 
-    assert !FakeFS.activated?
+    refute FakeFS.activated?
   end
 
   def test_FakeFS_method_deactivates_FakeFS_when_block_raises_exception
@@ -79,6 +79,6 @@ class FakeFSSafeTest < Test::Unit::TestCase
       'Nothing to do'
     end
 
-    assert !FakeFS.activated?
+    refute FakeFS.activated?
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,12 +1,7 @@
 $LOAD_PATH.unshift File.join(File.dirname(__FILE__), '..', 'lib')
 require 'fakefs/safe'
-require 'test/unit'
-
-begin
-  require 'redgreen'
-rescue LoadError
-  'Nothing to do'
-end
+require 'minitest/autorun'
+require 'minitest/rg'
 
 def act_on_real_fs
   fail ArgumentError unless block_given?

--- a/test/verify.rb
+++ b/test/verify.rb
@@ -7,7 +7,7 @@
 require 'test_helper'
 
 # FakeFs verifier test class
-class FakeFSVerifierTest < Test::Unit::TestCase
+class FakeFSVerifierTest < Minitest::Test
   class_mapping = {
     RealFile       => FakeFS::File,
     RealFile::Stat => FakeFS::File::Stat,
@@ -18,14 +18,14 @@ class FakeFSVerifierTest < Test::Unit::TestCase
 
   class_mapping.each do |real_class, fake_class|
     real_class.methods.each do |method|
-      define_method "test #{method} class method" do
+      define_method "test_#{method}_class_method" do
         assert fake_class.respond_to?(method),
                "#{fake_class}.#{method} not implemented"
       end
     end
 
     real_class.instance_methods.each do |method|
-      define_method("test #{method} instance method") do
+      define_method("test_#{method}_instance_method") do
         assert fake_class.instance_methods.include?(method),
                "#{fake_class}##{method} not implemented"
       end


### PR DESCRIPTION
Note: Test::Unit was removed from Ruby stdlib in 2.2.0 (MRI). I’ve replaced it with [Minitest](https://github.com/seattlerb/minitest) that is (almost) drop-in replacement.