### PR TITLE
Fixed premature closing of IO in Pathname#each_line

### DIFF
--- a/lib/fakefs/pathname.rb
+++ b/lib/fakefs/pathname.rb
@@ -629,8 +629,12 @@ module FakeFS
       # This method has existed since 1.8.1.
       #
       def each_line(*args, &block) # :yield: line
-        File.open(@path, 'r') do |io|
-          io.each_line(*args, &block)
+        if block_given?
+          File.open(@path, 'r') do |io|
+            io.each_line(*args, &block)
+          end
+        else
+          enum_for(:each_line, *args)
         end
       end
 

--- a/test/pathname_test.rb
+++ b/test/pathname_test.rb
@@ -34,37 +34,39 @@ class FakePathnameTest < Test::Unit::TestCase
   end
 
   def test_io_each_line_without_block_returns_enumerator
-    File.write(@path, '')
+    File.write(@path, "one\ntwo\nthree\n")
 
     assert @pathname.each_line.is_a?(Enumerator)
+    assert_equal %w(o t t), @pathname.each_line.map { |l| l[0] }
+    assert_equal ["one\ntwo\nth", "ree\n"], @pathname.each_line('th').to_a
   end
 
   def test_io_read_returns_file_contents
     File.write(@path, "some\ncontent")
 
-    assert_equal @pathname.read, "some\ncontent"
-    assert_equal @pathname.read(6), "some\nc"
-    assert_equal @pathname.read(4, 3), "e\nco"
+    assert_equal "some\ncontent", @pathname.read
+    assert_equal "some\nc", @pathname.read(6)
+    assert_equal "e\nco", @pathname.read(4, 3)
   end
 
   def test_io_binread_returns_file_contents
     File.write(@path, "some\ncontent")
 
-    assert_equal @pathname.binread, "some\ncontent"
-    assert_equal @pathname.binread(6), "some\nc"
-    assert_equal @pathname.binread(4, 3), "e\nco"
+    assert_equal "some\ncontent", @pathname.binread
+    assert_equal "some\nc", @pathname.binread(6)
+    assert_equal "e\nco", @pathname.binread(4, 3)
   end
 
   def test_io_binread_reads_contents_as_binary
     File.write(@path, "some\ncontent")
 
-    assert_equal @pathname.binread.encoding.name, 'ASCII-8BIT'
+    assert_equal 'ASCII-8BIT', @pathname.binread.encoding.name
   end
 
   def test_io_readlines_returns_array_of_lines
     File.write(@path, "one\ntwo\nthree\n")
 
-    assert_equal @pathname.readlines, ["one\n", "two\n", "three\n"]
+    assert_equal ["one\n", "two\n", "three\n"], @pathname.readlines
   end
 
   def test_io_sysopen_is_unsupported


### PR DESCRIPTION
The previous implementation of Pathname#each_line (see #220) wrapped
both kinds of invocation (block and block-less) in a File.open closure,
the latter resulting in an Enumerator that attempts to operate on a
prematurely closed IO object (resulting in an IOError upon actual
iteration). This fix properly implements the block-less invocation with
a recursing enumerator.

An additional assertion was added to the Pathname unit tests to cover
the case. Existing uses of assert_equal were also corrected to use the
right "expected" and "actual" argument position.