### PR TITLE
Fix FileSystem#chdir "path/to/file"

### DIFF
--- a/lib/fakefs/file_system.rb
+++ b/lib/fakefs/file_system.rb
@@ -85,6 +85,7 @@ module FakeFS
       dir_levels.push dir if blk
 
       fail Errno::ENOENT, dir unless new_dir
+      fail Errno::ENOTDIR, dir unless File.directory?(dir)
 
       dir_levels.push dir unless blk
       blk.call if blk


### PR DESCRIPTION
Currently, Dir#chdir(), FileUtils#cd(), and FileUtils#chdir() can move into a file, but the real system raises Errno::ENOTDIR in that case. So I change FileSystem#chdir() to check either the given path is a directory path.

```txt
irb(main):001:0> require "fileutils"
=> true
irb(main):002:0> FileUtils.touch "file"
=> ["file"]
irb(main):003:0> Dir.chdir "file"
Errno::ENOTDIR: Not a directory @ dir_chdir - file
        from (irb):3:in `chdir'
        from (irb):3
        from /home/user/.rbenv/versions/2.2.1/bin/irb:11:in `<main>'
irb(main):004:0> require "fakefs"
=> true
irb(main):005:0> FileUtils.touch "file"
=> ["file"]
irb(main):006:0> Dir.chdir "file"
=> nil
irb(main):007:0> Dir.pwd
=> "/file"
irb(main):008:0> exit
```
