### PR TITLE
Dir.glob should work with nested patterns

### DIFF
--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -1069,6 +1069,8 @@ class FakeFSTest < Minitest::Test
 
     assert_equal ['/path/bar', '/path/bar2'], Dir['/path/bar{2,}']
 
+    assert_equal ['/path/bar', '/path/foo'], Dir['{/nowhere,/path/{foo,bar}}']
+
     Dir.chdir '/path' do
       assert_equal ['foo'], Dir['foo']
     end


### PR DESCRIPTION
`Dir.glob` does not work with nested patterns. This PR contains only the failing test.