### PR TITLE
Follow the pattern of the new version of open-uri

### DIFF
--- a/lib/fakefs/kernel.rb
+++ b/lib/fakefs/kernel.rb
@@ -47,12 +47,12 @@ module FakeFS
       captives[:hijacked][name] = block || proc { |_args| }
     end
 
-    hijack :open do |*args, &block|
-      if args.first.start_with?('|')
+    hijack :open do |name, *args, &block|
+      if name.start_with?('|') ||
+          (name.respond_to?(:to_str) && %r{\A[A-Za-z][A-Za-z0-9+\-\.]*://} =~ name)
         # This is a system command
-        ::FakeFS::Kernel.captives[:original][:open].call(*args, &block)
+        ::FakeFS::Kernel.captives[:original][:open].call(name, *args, &block)
       else
-        name = args.shift
         FakeFS::File.open(name, *args, &block)
       end
     end

--- a/test/kernel_test.rb
+++ b/test/kernel_test.rb
@@ -24,6 +24,18 @@ class KernelTest < Minitest::Test
   end
 
   def test_fake_kernel_can_create_new_file
+    FakeFS.activate!
+
+    FileUtils.mkdir_p '/apath/to/'
+    open('/apath/to/file', 'w') do |f|
+      f << 'test'
+    end
+    assert_kind_of FakeFile, FileSystem.fs['apath']['to']['file']
+
+    FakeFS.deactivate!
+  end
+
+  def test_fake_kernel_can_create_new_file
     FakeFS do
       FileUtils.mkdir_p '/path/to/'
       open('/path/to/file', 'w') do |f|

--- a/test/kernel_test.rb
+++ b/test/kernel_test.rb
@@ -23,7 +23,7 @@ class KernelTest < Minitest::Test
     end
   end
 
-  def test_fake_kernel_can_create_new_file
+  def test_fake_kernel_can_create_new_file_activate_deactivate
     FakeFS.activate!
 
     FileUtils.mkdir_p '/apath/to/'


### PR DESCRIPTION
#312 #226 #290 

Open uri has changed in later versions of Ruby. This cause a continuous flow of calling `:open` on all objects which supported it. Unfortunately the previous hijack solution created a `:open` on every object.

