### PR TITLE
Fix RuboCop offenses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,17 +8,17 @@ AllCops:
     - files/**/*
     - templates/**/*
     - etc/**/*
-MethodLength:
+Metrics/MethodLength:
   Exclude:
     - lib/**/*
     - test/**/*.rb
     - spec/**/*.rb
-ClassLength:
+Metrics/ClassLength:
   Enabled: false
-LineLength:
+Metrics/LineLength:
   Exclude:
     - test/**/*
-ParameterLists:
+Metrics/ParameterLists:
   Enabled: false
 Metrics/CyclomaticComplexity:
   Severity: warning
@@ -40,6 +40,6 @@ Style/MethodName:
   Enabled: false
 Style/ModuleFunction:
   Enabled: false
-TrivialAccessors:
+Style/TrivialAccessors:
   Enabled: true
   ExactNameMatch: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,6 +15,8 @@ Metrics/MethodLength:
     - spec/**/*.rb
 Metrics/ClassLength:
   Enabled: false
+Metrics/ModuleLength:
+  Enabled: false
 Metrics/LineLength:
   Exclude:
     - test/**/*
@@ -33,12 +35,18 @@ Metrics/BlockNesting:
   Max: 4
 Metrics/AbcSize:
   Enabled: false
+Performance/StringReplacement:
+  Enabled: false
+Style/ParallelAssignment:
+  Enabled: false
 Style/PredicateName:
   Exclude:
     - lib/fakefs/file.rb
 Style/MethodName:
   Enabled: false
 Style/ModuleFunction:
+  Enabled: false
+Style/SymbolProc:
   Enabled: false
 Style/TrivialAccessors:
   Enabled: true

--- a/fakefs.gemspec
+++ b/fakefs.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake", "~> 10.3"
   spec.add_development_dependency "rspec", "~> 3.1"
-  spec.add_development_dependency 'rubocop', '~>0.30'
+  spec.add_development_dependency 'rubocop', '~> 0.35.0'
   spec.add_development_dependency 'minitest', '~> 5.5'
   spec.add_development_dependency 'minitest-rg', '~> 5.1'
 end

--- a/lib/fakefs/fileutils.rb
+++ b/lib/fakefs/fileutils.rb
@@ -199,12 +199,10 @@ module FakeFS
       list.each do |f|
         if File.exist?(f)
           uid = if user
-                  user.to_s.match(/[0-9]+/) ? user.to_i :
-                    Etc.getpwnam(user).uid
+                  user.to_s.match(/\d+/) ? user.to_i : Etc.getpwnam(user).uid
                 end
           gid = if group
-                  group.to_s.match(/[0-9]+/) ? group.to_i :
-                    Etc.getgrnam(group).gid
+                  group.to_s.match(/\d+/) ? group.to_i : Etc.getgrnam(group).gid
                 end
           File.chown(uid, gid, f)
         else

--- a/lib/fakefs/pathname.rb
+++ b/lib/fakefs/pathname.rb
@@ -621,7 +621,7 @@ module FakeFS
     end
 
     # Pathname class
-    class Pathname    # * IO *
+    class Pathname # * IO *
       #
       # #each_line iterates over the line in the file.
       # It yields a String object for each line.
@@ -662,7 +662,7 @@ module FakeFS
     end
 
     # Pathname class
-    class Pathname    # * File *
+    class Pathname # * File *
       # See <tt>File.atime</tt>.  Returns last access time.
       def atime
         File.atime(@path)
@@ -790,7 +790,7 @@ module FakeFS
     end
 
     # Pathname class
-    class Pathname    # * FileTest *
+    class Pathname # * FileTest *
       # See <tt>FileTest.blockdev?</tt>.
       def blockdev?
         FileTest.blockdev?(@path)
@@ -913,7 +913,7 @@ module FakeFS
     end
 
     # Pathname class
-    class Pathname    # * Dir *
+    class Pathname # * Dir *
       # See <tt>Dir.glob</tt>.  Returns or yields Pathname objects.
       def self.glob(*args) # :yield: pathname
         if block_given?
@@ -962,7 +962,7 @@ module FakeFS
     end
 
     # Pathname class
-    class Pathname    # * Find *
+    class Pathname # * Find *
       #
       # Pathname#find is an iterator to traverse a directory tree
       # in a depth first manner.
@@ -985,7 +985,7 @@ module FakeFS
     end
 
     # Pathname class
-    class Pathname    # * FileUtils *
+    class Pathname # * FileUtils *
       # See <tt>FileUtils.mkpath</tt>.  Creates a full path, including any
       # intermediate directories that don't yet exist.
       def mkpath
@@ -1005,7 +1005,7 @@ module FakeFS
     end
 
     # Pathname class
-    class Pathname    # * mixed *
+    class Pathname # * mixed *
       # Removes a file or directory, using <tt>File.unlink</tt> or
       # <tt>Dir.unlink</tt> as necessary.
       def unlink

--- a/test/fake/file/join_test.rb
+++ b/test/fake/file/join_test.rb
@@ -11,7 +11,7 @@ class FileJoin < Minitest::Test
   end
 
   [
-    %w(a b),  %w(a/ b), %w(a /b), %w(a/ /b), %w(a / b)
+    %w(a b), %w(a/ b), %w(a /b), %w(a/ /b), %w(a / b)
   ].each_with_index do |args, i|
     define_method "test_file_join_#{i}" do
       assert_equal RealFile.join(args), File.join(args)

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -852,7 +852,7 @@ class FakeFSTest < Minitest::Test
     filename = "\u65e5\u672c\u8a9e.txt"
     expected_contents = 'Yokudekimashita'
     # nothing raised
-    File.open(filename,  mode: 'w') { |f| f.write "#{expected_contents}" }
+    File.open(filename, mode: 'w') { |f| f.write "#{expected_contents}" }
     contents = File.open("/#{filename}").read
     assert_equal contents, expected_contents
   end


### PR DESCRIPTION
Travis is testing with a newer version of RuboCop than FakeFS was using, so builds for newer pull requests are failing.

This PR locks RuboCop to a minor version, only allowing patch upgrades, so builds should be stable.